### PR TITLE
refactor: extend switch component

### DIFF
--- a/examples/vanilla-extract-react/src/components/Switch/switch.types.ts
+++ b/examples/vanilla-extract-react/src/components/Switch/switch.types.ts
@@ -1,0 +1,5 @@
+export interface ISwitchProps {
+  status: boolean;
+  onChange: React.Dispatch<React.SetStateAction<boolean>>;
+  isDisabled?: boolean;
+}

--- a/lib/src/components/Switch/Switch.tsx
+++ b/lib/src/components/Switch/Switch.tsx
@@ -2,14 +2,18 @@ import { slider, switchInputStyle, switchLayout } from "./switch.css";
 import { ISwitchProps } from "./switch.types";
 import "./switch-global-styles.css";
 
+type SwitchProps = ISwitchProps & JSX.IntrinsicElements["input"];
+
 export const Switch = ({
   status,
   onChange,
   isDisabled = false,
-}: ISwitchProps) => {
+  ...nativeProps
+}: SwitchProps) => {
   return (
     <label className={switchLayout}>
       <input
+        {...nativeProps}
         className={switchInputStyle}
         type="checkbox"
         checked={status}


### PR DESCRIPTION
## Description
- extend the switch component to accepting native props

## Motivation and Context
- allow switch component to accept native checkbox input functionalities

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
