### PR TITLE
Updates to Documentation

### DIFF
--- a/docs/docs/components/badge.mdx
+++ b/docs/docs/components/badge.mdx
@@ -68,14 +68,14 @@ import { Badge } from "@hover-design/react";
 ```jsx
 <div className="App">
   <Badge color="red" label="3" shape="rounded" position="top-end">
-    <Button variant="dark">Notifications</Button>
+    <Button variant="default">Notifications</Button>
   </Badge>
 </div>
 ```
 
 <div className="App">
   <Badge color="red" label="3" shape="rounded" position="top-end">
-    <Button variant="dark">Notifications</Button>
+    <Button variant="default">Notifications</Button>
   </Badge>
 </div>
 
@@ -86,17 +86,17 @@ import { Badge } from "@hover-design/react";
   <Button variant="dark">
     <Badge color="red" label="New" /> Profile
   </Button>
-  <Button variant="dark">
+  <Button variant="default">
     Notifications <Badge color="red" label="7" shape="rounded" />
   </Button>
 </div>
 ```
 
 <div className="App">
-  <Button variant="dark">
+  <Button variant="default">
     <Badge color="red" label="New" /> Profile
   </Button>
-  <Button variant="dark">
+  <Button variant="default">
     Notifications <Badge color="red" label="7" shape="rounded" />
   </Button>
 </div>

--- a/docs/docs/components/card.mdx
+++ b/docs/docs/components/card.mdx
@@ -16,75 +16,72 @@ import { Card } from "@hover-design/react";
 
 import "@hover-design/react/dist/style.css";
 import { Card } from "@hover-design/react";
-export const CardComponent = ({ variant, children }) => (
-  <Card variant={variant}>{children}</Card>
-);
 
 ```jsx
 <div className="App">
-  <CardComponent variant="plain">
+  <Card variant="plain">
     <h3>I am a card heading</h3>
     <p>I am card Content</p>
-  </CardComponent>
+  </Card>
 </div>
 ```
 
 <!-- ![Button](https://i.imgur.com/BeBATSh.jpg) -->
 
-<CardComponent variant="plain">
+<Card variant="plain">
   <h3>I am a card heading</h3>
   <p>I am card Content</p>
-</CardComponent>
+</Card>
 
 ##### Card Outline
 
 ```jsx
 <div className="App">
-  <CardComponent variant="outline">
+  <Card variant="outline">
     <h3>I am a card heading</h3>
     <p>I am card Content</p>
-  </CardComponent>
+  </Card>
 </div>
 ```
 
 <!-- ![Button](https://i.imgur.com/iGIVhXN.jpg) -->
 
-<CardComponent variant="outline">
+<Card variant="outline">
   <h3>I am a card heading</h3>
   <p>I am card Content</p>
-</CardComponent>
+</Card>
 
 ##### Card Solid
 
 ```jsx
-<CardComponent variant="solid">
+<Card variant="solid">
   <h3>I am a card heading</h3>
   <p>I am card Content</p>
-</CardComponent>
+</Card>
 ```
 
 <!-- ![Button](https://i.imgur.com/AbrmEdn.jpg) -->
 
-<CardComponent variant="solid">
+<Card variant="solid">
   <h3>I am a card heading</h3>
   <p>I am card Content</p>
-</CardComponent>
+</Card>
 
 ##### Card Shadow
 
 ```jsx
-<CardComponent variant="shadow">
+<Card variant="shadow">
   <h3>I am a card heading</h3>
   <p>I am card Content</p>
-</CardComponent>
+</Card>
 ```
 
 <!-- ![Button](https://i.imgur.com/iPfqa7x.jpg) -->
 
-<CardComponent variant="shadow">
+<Card variant="shadow">
   <h3>I am a card heading</h3>
   <p>I am card Content</p>
-</CardComponent>
+</Card>
 
 ### Props Referece
 

--- a/docs/docs/components/list.mdx
+++ b/docs/docs/components/list.mdx
@@ -98,5 +98,5 @@ export const ListItemComp = ({ variant, children }) => (
 | Attributes |                                                              Values                                                               | Optional ? |
 | :--------- | :-------------------------------------------------------------------------------------------------------------------------------: | ---------: |
 | variant    |                                                  `horizontal` &#124; `vertical`                                                   |        Yes |
-| type       | `square` &#124; `circle` &#124; `\1F44D` &#124; [listStyleType](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type) |        Yes |
+| type       | `square` &#124; `circle` &#124; [`\1F44D`](https://www.w3schools.com/charsets/ref_emoji.asp) &#124; [listStyleType](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type) |        Yes |
 | children   |                                                          React.Children                                                           |        Yes |

--- a/docs/docs/components/nativeSelect.mdx
+++ b/docs/docs/components/nativeSelect.mdx
@@ -123,14 +123,11 @@ const options = [
 
 <div className="App">
   <NativeSelect
-    borderRadius={"50px"}
-    error="This is an error"
+    borderRadius={"60px"}
     options={options}
   />
 </div>;
 ```
-
-> Note: **error** can also be passed as a boolean.
 
 <NativeSelect
   borderRadius={"60px"}

--- a/docs/docs/components/text-area.mdx
+++ b/docs/docs/components/text-area.mdx
@@ -25,10 +25,10 @@ import { TextArea } from "@hover-design/react";
 ### Fixedsize
 
 ```jsx
-<TextArea placeholder="Fixedsize" fixedSize="true"></TextArea>
+<TextArea placeholder="Fixedsize" fixedSize={true}></TextArea>
 ```
 
-<TextArea placeholder="Fixedsize" fixedSize="true"></TextArea>
+<TextArea placeholder="Fixedsize" fixedSize={true}></TextArea>
 
 ### Rows & Cols
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- List - Added a hyperlink to all available emoji codes for reference
- Badge - "Badge with position", "Badge with a child" - Documentation uses button variant "dark" which is not available in the library, switching to "default".
- Card - Imports "Card" from library but uses "CardComponent" throughout the examples. When people use this it will error out. In the code "CardComponent" is defined as 
	`export const CardComponent = ({ variant, children }) => (<Card variant={variant}>{children}</Card>);` which is an abstraction of Card component. So removed this and replaced it everywhere with just "Card"
- Native Select - "NativeSelect Rounded" remove error prop to match the expected outcome shown in the docs (i.e, normal rounded Native Select without any errors)
- TextArea - fixedSize prop should be boolean, not string

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
