### PR TITLE
BUGFIX: Broken links and spelling errors in contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export const Component = () => <Button>I am a Button</Button>;
 
 ## Contribution
 
-Intrested in contributing to hover? visit our [Contribution Guide](https://hover.style/docs/contribution)
+Interested in contributing to hover? visit our [Contribution Guide](https://hover.antstack.com/docs/contribution)
 
 <p style="display: inline-block; margin-top:8px">Made with ❤️ by</p> 
 <a href="https://www.antstack.com/">

--- a/docs/docs/wiki/getting_started.md
+++ b/docs/docs/wiki/getting_started.md
@@ -9,15 +9,15 @@ description: Hover Wiki - Getting Started
 
 Hover Design is mainly made on Vanilla Extract which requires basic TypeScript Knowledge. With that we need basic knowledge in react, you should know about Props, Children and Refs.
 
-To get started make yourself famaliar with:
+To get started make yourself familiar with:
 
-- [Vanilla Extract](https://vanilla-extract.style/documentation)
+- [Vanilla Extract](https://vanilla-extract.style/documentation/getting-started)
 - React
 - Basic Typescript
 - Basics of Storybook and stories, we use [Ladle](https://ladle.dev/)
 
-We use the [recipies](https://vanilla-extract.style/documentation/recipes-api/) api heavily along with styles.
+We use the [recipes](https://vanilla-extract.style/documentation/recipes-api/) api heavily along with styles.
 
-We believe in acessibility first way of developing and to ensure that we always extend HTML elements rather than using css and js to heavily modify a `<div>`
+We believe in accessibility first way of developing and to ensure that we always extend HTML elements rather than using css and js to heavily modify a `<div>`
 
 Make sure to go through [Contribution Guide](/docs/contribution) and contact [@pruthvi2103](https://github.com/pruthvi2103) or [@Raalzz](https://github.com/Raalzz) via slack for planning out components.

--- a/docs/docs/wiki/playbooks/git_playbook.md
+++ b/docs/docs/wiki/playbooks/git_playbook.md
@@ -37,12 +37,12 @@ Always commit and push code with a WIP in the description if changes are not yet
 When pair programming add a co-author, to add a co-author write your message like this
 
 ```jsx
-git commit -m "c**ommit title
+git commit -m "**commit title
 
 Commit body
 
 Co-authored-by: name <additional-dev-1@example.com>
-Co-authored-by: name <additional-dev-2@example.com>"**
+Co-authored-by: name <additional-dev-2@example.com>**"
 ```
 
 Helps to know the people who have contributed to a specific piece of code and can help with context switch and KT
@@ -51,7 +51,7 @@ Do not commit editor specific files and always make sure your Linter and Formatt
 
 ## Reviews take top priority
 
-When a PR is up for review it will will reviewed so that no one is blocked on review. also at a time one developer should work on 1 issue unless it’s blocked.
+When a PR is up for review it will be reviewed so that no one is blocked on review. also at a time one developer should work on 1 issue unless it’s blocked.
 
 ## Use squash and merge for PR’s to main
 
@@ -69,7 +69,7 @@ Reviews should be clear too, raising nitpicks and possible questions that you ma
 
 ## Never mix tasks in one PR
 
-Its always better to raise 2 different PRs if you think that you are covering more than one concise feature. Eg: you modify the way padding is applied throughout the app while making a navbar, seperate the padding calculation into a different PR so that its clear.
+Its always better to raise 2 different PRs if you think that you are covering more than one concise feature. Eg: you modify the way padding is applied throughout the app while making a navbar, separate the padding calculation into a different PR so that its clear.
 
 ## Always link the proper milestone and project
 


### PR DESCRIPTION
Closes #173 

Broken links and spelling errors in contribution guidelines

<!--- Provide a general summary of your changes in the Title above -->

## Description

1. contribution guidelines on github monorepo readme should point to updated link.
2. [Github playbook](https://hover.antstack.com/docs/wiki/playbooks/git_playbook) should not contain wrongly typed git commit message example.
3. [Prerequisites](https://hover.antstack.com/docs/wiki/getting_started) should be spelled correctly for better user experience.

<!--- Describe your changes in detail -->

## Motivation and Context

Updated the issues that came to notice while reading the documentation.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
issue number #173 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
