### PR TITLE
Add "type": "module" to react/package.json

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,6 +9,7 @@
     }
   },
   "types": "./src/index.ts",
+  "type": "module",
   "files": [
     "src"
   ],


### PR DESCRIPTION
## Description

"type": "module" is added to the react/package.json file. 

## Motivation and Context

When attempting to import a component from the hover-design/react package into an [astro.build](astro.build) project, astro would have an issue evaluting the code with the sever side rending module. The error is: 
`SyntaxError: Cannot use import statement outside a module`

The ssr module correctly renders the hover-design components after "type": "module" is added to the react/package.json file. 

## How Has This Been Tested?

Tested locally with astro builds.

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
