### PR TITLE
bug: fixes double style in table

### DIFF
--- a/docs/docs/components/table.mdx
+++ b/docs/docs/components/table.mdx
@@ -290,6 +290,8 @@ import {
 | horizontalSpacing           |               `string`                |      `0`      |        Yes |
 | overrideTableClass          |               `string`                |       -       |        Yes |
 | overrideTableContainerClass |               `string`                |       -       |        Yes |
+| wrapperStyle                |          `CSS Style Object`           |       -       |        Yes |
+| wrapperClassName            |               `string`                |       -       |        Yes |
 
 The table component renders a `div` that wraps the table to not allow the table to overflow the parent, this can be customized by sending a class to `overrideTableContainerClass`
 

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -27,6 +27,8 @@ const Table: ForwardRefRenderFunction<HTMLTableElement, InitialTableProps> = (
     children,
     className,
     style,
+    wrapperStyle,
+    wrapperClassName,
     horizontalSpacing = "0",
     ...nativeProps
   },
@@ -50,9 +52,9 @@ const Table: ForwardRefRenderFunction<HTMLTableElement, InitialTableProps> = (
 
   return (
     <div
-      style={{ ...tableContainerInlineVars, ...(style || {}) }}
+      style={{ ...tableContainerInlineVars, ...(wrapperStyle || {}) }}
       className={`${tableContainerDefaults} ${tableContainerThemeClass} ${overrideTableContainerClass} ${
-        className || ""
+        wrapperClassName || ""
       }`}
     >
       <table

--- a/packages/react/src/components/Table/Table.types.ts
+++ b/packages/react/src/components/Table/Table.types.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { CSSProperties } from "react";
 
 export interface InitialTableProps
   extends React.DetailedHTMLProps<
@@ -19,6 +19,8 @@ export interface InitialTableProps
   overrideTableClass?: string;
   className?: string;
   horizontalSpacing?: string;
+  wrapperStyle?: CSSProperties;
+  wrapperClassName?: string;
 }
 
 export type ITableThemeVars = [


### PR DESCRIPTION
Fixes a bug that had className and styles applied to both wrapper and child.

## Description

Fixes a bug that had className and styles applied to both wrapper and child.

## Motivation and Context
This bug was duplicating styles on parent and child.


## How Has This Been Tested?
Local build success

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
